### PR TITLE
Fix utilities CSS filename

### DIFF
--- a/myPj/julia-set/css/d3-utilities.css
+++ b/myPj/julia-set/css/d3-utilities.css
@@ -1,0 +1,6 @@
+/* d3-utilities.css */
+
+/* Utility styles for status display */
+.status-stopped {
+  color: #ff6666 !important; /* show stopped/error status in red */
+}

--- a/myPj/julia-set/d3-julia.html
+++ b/myPj/julia-set/d3-julia.html
@@ -31,7 +31,7 @@
   <link rel="stylesheet" href="css/d3-base.css" />
   <link rel="stylesheet" href="css/d3-nav.css" />
   <link rel="stylesheet" href="css/d3-components.css" />
-  <link rel="stylesheet" href="css/d3-utilities.cs" />
+  <link rel="stylesheet" href="css/d3-utilities.css" />
   <script type="importmap">
   {
     "imports": {

--- a/myPj/qt-st-visual/js/modules/julia-inverse/d3-julia.html
+++ b/myPj/qt-st-visual/js/modules/julia-inverse/d3-julia.html
@@ -31,7 +31,7 @@
   <link rel="stylesheet" href="css/d3-base.css" />
   <link rel="stylesheet" href="css/d3-nav.css" />
   <link rel="stylesheet" href="css/d3-components.css" />
-  <link rel="stylesheet" href="css/d3-utilities.cs" />
+  <link rel="stylesheet" href="css/d3-utilities.css" />
   <script type="importmap">
   {
     "imports": {


### PR DESCRIPTION
## Summary
- rename `d3-utilities.cs` to `d3-utilities.css`
- add `.status-stopped` rule
- update html references to the new CSS file

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68565345c4d8832b9c35b569e304d579