### PR TITLE
Fix duplicate canvas container ID

### DIFF
--- a/myPj/qt-st-visual-old/partials/d3-julia-main.html
+++ b/myPj/qt-st-visual-old/partials/d3-julia-main.html
@@ -1,4 +1,4 @@
-<div id="canvas-container" class="position-relative overflow-hidden flex-grow-1">
+<div id="main-container" class="position-relative overflow-hidden flex-grow-1">
 	<canvas id="legend-canvas"></canvas>
 	<button id="btn-top-view" class="btn btn-top-view" type="button">
 	  <i class="bi bi-grid-3x2-gap icon" aria-hidden="true"></i>

--- a/myPj/qt-st-visual/partials/d3-julia-main.html
+++ b/myPj/qt-st-visual/partials/d3-julia-main.html
@@ -1,4 +1,4 @@
-<div id="canvas-container" class="position-relative overflow-hidden flex-grow-1">
+<div id="main-container" class="position-relative overflow-hidden flex-grow-1">
 	<canvas id="legend-canvas"></canvas>
 	<button id="btn-top-view" class="btn btn-top-view" type="button">
 	  <i class="bi bi-grid-3x2-gap icon" aria-hidden="true"></i>


### PR DESCRIPTION
## Summary
- ensure the canvas container ID only lives in `d3-julia-canvas-container.html`
- update `d3-julia-main.html` in both versions to use `main-container`

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403)*

------
https://chatgpt.com/codex/tasks/task_e_68566d3717b8832b9239bebad5d4cf32