### PR TITLE
Fix speed multiplier call typo

### DIFF
--- a/myPj/qt-st-visual/js/modules/quantStereo/handlers/qtSpeedHandlers.js
+++ b/myPj/qt-st-visual/js/modules/quantStereo/handlers/qtSpeedHandlers.js
@@ -8,7 +8,7 @@ export function getSpeedHandlers(animController) {
       handler: e => {
       const v = parseFloat(e.target.value);
       if (!isNaN(v) && v > 0) {
-        animController.etSpeedMultiplier(v);
+        animController.setSpeedMultiplier(v);
       } else {
         e.target.value = '1';
         animController.setSpeedMultiplier(1);


### PR DESCRIPTION
## Summary
- correct wrong method call in qtSpeedHandlers

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68566d70e2b8832b9efb63cee730a7b5