### PR TITLE
Fix offcanvas speed control handlers

### DIFF
--- a/myPj/qt-st-visual/js/modules/quantStereo/handlers/qtSpeedHandlers.js
+++ b/myPj/qt-st-visual/js/modules/quantStereo/handlers/qtSpeedHandlers.js
@@ -8,7 +8,7 @@ export function getSpeedHandlers(animController) {
       handler: e => {
       const v = parseFloat(e.target.value);
       if (!isNaN(v) && v > 0) {
-        animController.etSpeedMultiplier(v);
+        animController.setSpeedMultiplier(v);
       } else {
         e.target.value = '1';
         animController.setSpeedMultiplier(1);
@@ -38,7 +38,7 @@ export function getSpeedHandlers(animController) {
         animController.setTextureSpeed(v);
       } else {
         e.target.value = '0';
-        animController.setTextureSpeed(v);
+        animController.setTextureSpeed(0);
       }
       }
     },


### PR DESCRIPTION
## Summary
- fix typo `etSpeedMultiplier` to `setSpeedMultiplier`
- handle invalid texture speed input by resetting to `0`

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68586fe0ec54832b998e75bb0b9e8512