### PR TITLE
Fix offcanvas event binding

### DIFF
--- a/myPj/qt-st-visual/js/modules/quantStereo/qtUIControlsModule.js
+++ b/myPj/qt-st-visual/js/modules/quantStereo/qtUIControlsModule.js
@@ -25,7 +25,10 @@ export class UIControlsModule {
 
     // Offcanvas／Navbar 用の FormModule
     this.offcanvasModule = new FormModule({
-      rootSelector: '#offcanvasForm',
+      // Offcanvas 内のフォーム要素に直接バインドする
+      // div.offcanvas では Bootstrap の処理と競合して
+      // イベントが正しく拾えない場合があるため
+      rootSelector: '#offcanvasForm form',
       handlers: [
                  ...getTopViewHandlers(camera, controls), 
                  ...getCameraHandlers({ controls, animController }),


### PR DESCRIPTION
## Summary
- adjust selector used by FormModule to bind handlers inside the offcanvas

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_685920ac1440832bacdc04f2b4a8c6ac