### PR TITLE
Wait for offcanvas form before running modules

### DIFF
--- a/myPj/qt-st-visual/app.js
+++ b/myPj/qt-st-visual/app.js
@@ -13,10 +13,11 @@ document.addEventListener('DOMContentLoaded', async () =>
     // ナビ・Offcanvas を読み込む
     await loadPartials(alg);
     console.log('[app] loadPartials() が完了');
-    // #canvas-container が本当に挿入されるまで待つ
+    // #canvas-container と Offcanvas の <form> が挿入されるまで待つ
     const waitForContainer = () => {
       const container = document.getElementById('canvas-container');
-      if (container) {
+      const offcanvasForm = document.querySelector('#offcanvasForm form');
+      if (container && offcanvasForm) {
         startMain(alg);
         console.log('[app] startMain() を呼び出し完了: alg=', alg);
       } else {


### PR DESCRIPTION
## Summary
- guard the app startup until both the canvas container and Offcanvas `<form>` exist

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68592268ca68832bba49b2e1c13fd970