### PR TITLE
Remove config-complete button handler

### DIFF
--- a/myPj/qt-st-visual/js/modules/julia-inverse/handlers/formHandlers.js
+++ b/myPj/qt-st-visual/js/modules/julia-inverse/handlers/formHandlers.js
@@ -25,12 +25,6 @@ export function getFormHandlers(onReset) {
       selector: '#chk-legend',
       type:     'change',
       handler:  () => { toggleLegend(); onReset(); }
-    },
-    {
-      // 「設定完了」ボタン
-      selector: '#config-complete-btn',
-      type:     'click',
-      handler:  () => onReset()
     }
   ];
 }


### PR DESCRIPTION
## Summary
- remove the event handler for `#config-complete-btn`

## Testing
- `python3 -m http.server 8000` *(fails: UI interaction cannot be verified in CI)*

------
https://chatgpt.com/codex/tasks/task_e_685925a821cc832bb5e04671b5187ed5