### PR TITLE
Fix offcanvas speed input persistence

### DIFF
--- a/myPj/qt-st-visual/js/modules/julia-inverse/d3UIControlsModule.js
+++ b/myPj/qt-st-visual/js/modules/julia-inverse/d3UIControlsModule.js
@@ -65,6 +65,7 @@ export class UIControlsModule {
       { id: 'input-im',   value: Config.FORM_DEFAULTS.im },
       { id: 'input-n',    value: Config.FORM_DEFAULTS.N },
       { id: 'input-iter', value: Config.FORM_DEFAULTS.maxIter },
+      { id: 'input-interval', value: Config.DRAW_PARAMS.interval },
     ];
     mapping.forEach(({ id, value }) => {
       const el = document.getElementById(id);

--- a/myPj/qt-st-visual/js/modules/julia-inverse/handlers/formHandlers.js
+++ b/myPj/qt-st-visual/js/modules/julia-inverse/handlers/formHandlers.js
@@ -1,7 +1,7 @@
 // modules/julia-inverse/ui/handlers/formHandlers.js
 
 import { toggleLegend } from '../ui/d3-legend-sub.js';
-import { FORM_DEFAULTS } from '../d3-config.js';
+import { FORM_DEFAULTS, DRAW_PARAMS } from '../d3-config.js';
 
 /**
  * Offcanvas フォーム内の各要素に紐づくハンドラを返す
@@ -24,6 +24,20 @@ export function getFormHandlers(onReset) {
       selector: '#chk-legend',
       type:     'change',
       handler:  () => { toggleLegend(); onReset(); }
+
+    },
+    {
+      // interval speed input
+      selector: '#input-interval',
+      type:     'change',
+      handler:  e => {
+        const v = parseInt(e.target.value, 10);
+        if (!isNaN(v) && v > 0) {
+          DRAW_PARAMS.interval = v;
+        } else {
+          e.target.value = String(DRAW_PARAMS.interval);
+        }
+      }
 
     },
     {
@@ -50,9 +64,11 @@ function updateDefaults() {
   const im   = getNumber('input-im',   parseFloat);
   const n    = getNumber('input-n',    v => parseInt(v, 10));
   const iter = getNumber('input-iter', v => parseInt(v, 10));
+  const interval = getNumber('input-interval', v => parseInt(v, 10));
 
   if (re   !== null) FORM_DEFAULTS.re      = re;
   if (im   !== null) FORM_DEFAULTS.im      = im;
   if (n    !== null) FORM_DEFAULTS.N       = n;
   if (iter !== null) FORM_DEFAULTS.maxIter = iter;
+  if (interval !== null) DRAW_PARAMS.interval = interval;
 }

--- a/myPj/qt-st-visual/partials/d3-julia-offcanvas.html
+++ b/myPj/qt-st-visual/partials/d3-julia-offcanvas.html
@@ -78,6 +78,18 @@
         />
       </div>
 
+      <!-- interval (ms) -->
+      <div class="mb-3">
+        <label for="input-interval" class="form-label">Interval (ms)</label>
+        <input
+          type="number"
+          min="100"
+          step="50"
+          class="form-control form-control-sm"
+          id="input-interval"
+        />
+      </div>
+
       <!-- ステータス表示（白文字で） -->
       <div class="mb-3 d-none">
         <span id="status" class="fs-6 fw-bold text-white">(待機中)</span>


### PR DESCRIPTION
## Summary
- add interval speed input to Julia inverse offcanvas form
- sync interval value in UI initialization
- update form handlers to store interval value in DRAW_PARAMS

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68592d601e60832b96f3c68a4aa3f965