### PR TITLE
Update defaults when form inputs change

### DIFF
--- a/myPj/qt-st-visual/js/modules/julia-inverse/handlers/formHandlers.js
+++ b/myPj/qt-st-visual/js/modules/julia-inverse/handlers/formHandlers.js
@@ -27,6 +27,27 @@ export function getFormHandlers(onReset) {
 
     },
     {
+      // 入力値変更時にデフォルト値を更新
+      selector: '#input-re',
+      type:     'change',
+      handler:  updateDefaults
+    },
+    {
+      selector: '#input-im',
+      type:     'change',
+      handler:  updateDefaults
+    },
+    {
+      selector: '#input-n',
+      type:     'change',
+      handler:  updateDefaults
+    },
+    {
+      selector: '#input-iter',
+      type:     'change',
+      handler:  updateDefaults
+    },
+    {
       // 設定完了ボタン
       selector: '#config-complete-btn',
       type:     'click',


### PR DESCRIPTION
## Summary
- hook change events on offcanvas form fields

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68593cc977b8832b90d80e8ff1df301d