### PR TITLE
Fix stack overflow when calculating max value in color utilities

### DIFF
--- a/myPj/inverse/js/threeInverseAnimate-main.js
+++ b/myPj/inverse/js/threeInverseAnimate-main.js
@@ -112,7 +112,9 @@ function createColoredPoints(points, baseColor, stage, iter) {
   // (1) 全点の Z 値を一旦配列に集める
   const zValues = points.map(z => getZ(z, { stage, iter }));
   // (2) maxZ を求める（0SS防止で最低値を 1e-6 に）
-  const maxZ = Math.max(...zValues, 1e-6);
+  // Math.max(...zValues) だと要素数が多い場合にスタックオーバーフロー
+  // を起こす可能性があるため reduce で計算する
+  const maxZ = zValues.reduce((acc, v) => (v > acc ? v : acc), 1e-6);
 
   // 頂点バッファ用の TypedArray
   const posArray = new Float32Array(points.length * 3);

--- a/myPj/julia-set/js/3d/renderer/d3-utils.js
+++ b/myPj/julia-set/js/3d/renderer/d3-utils.js
@@ -39,7 +39,10 @@ export function createColoredPoints3D(
   const zValues = points.map(pt => getZ(pt, { stage, iter }));
 
   // ── 2) zValues の最大値を求める（最低でも 1e-6 を下限とする） ──
-  const maxZ = Math.max(...zValues, 1e-6);
+  // Math.max(...zValues) は配列が大きい場合に引数展開で
+  // "Maximum call stack size exceeded" を起こし得るため
+  // reduce で安全に最大値を計算する
+  const maxZ = zValues.reduce((acc, v) => (v > acc ? v : acc), 1e-6);
 
   // ── 3) BufferGeometry 用の TypedArray を準備 ──
   //    ・posArray: 座標バッファ (x, y, z) が 3 * points.length

--- a/myPj/qt-st-visual/js/modules/julia-inverse/renderer/d3-utils.js
+++ b/myPj/qt-st-visual/js/modules/julia-inverse/renderer/d3-utils.js
@@ -39,7 +39,10 @@ export function createColoredPoints3D(
   const zValues = points.map(pt => getZ(pt, { stage, iter }));
 
   // ── 2) zValues の最大値を求める（最低でも 1e-6 を下限とする） ──
-  const maxZ = Math.max(...zValues, 1e-6);
+  // Math.max(...zValues) だと配列が大きい場合に引数展開で
+  // "Maximum call stack size exceeded" が発生することがあるため
+  // reduce を用いて最大値を求める
+  const maxZ = zValues.reduce((acc, v) => (v > acc ? v : acc), 1e-6);
 
   // ── 3) BufferGeometry 用の TypedArray を準備 ──
   //    ・posArray: 座標バッファ (x, y, z) が 3 * points.length


### PR DESCRIPTION
## Summary
- avoid "Maximum call stack size exceeded" by using `reduce` instead of spreading arrays in `Math.max`

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a12bbcc3c832bbc0aa5e2efc65350