### PR TITLE
Add devcontainer for Codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:3.2
+
+# Set working directory
+WORKDIR /workspace
+
+# Install bundler
+RUN gem install bundler
+
+# Copy Gem files first for caching
+COPY Gemfile Gemfile.lock* ./
+RUN bundle install
+
+# Copy the rest of the project
+COPY . .
+
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+    "name": "pjdhiro-dev",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "postCreateCommand": "bundle install",
+    "postStartCommand": "rake go",
+    "customizations": {
+        "vscode": {
+            "settings": {},
+            "extensions": [
+                "rebornix.Ruby"
+            ]
+        }
+    },
+    "forwardPorts": [4000]
+}

--- a/README.md
+++ b/README.md
@@ -2,13 +2,19 @@
 
 ## about
 
-- Github pages 公開URL  
+- Github pages 公開URL
 [https://uminomae.github.io/pjdhiro/](https://uminomae.github.io/pjdhiro/)
 
-- 本サイトは下記のBLOGの内容について解説した際の対話をもとに構成されています  
+- 本サイトは下記のBLOGの内容について解説した際の対話をもとに構成されています
 [https://pjdhiro.blogspot.com/](https://pjdhiro.blogspot.com/)
 
 ## 開発時
 
-- rake go　で開発環境を実行
+- `rake go` で開発環境を実行
   - http://127.0.0.1:4000/pjdhiro/
+
+## GitHub Codespaces での起動
+
+1. GitHub のリポジトリページで **Code** ボタンをクリックし、**Open with Codespaces** を選択します。
+2. Codespace の作成が完了すると自動で `bundle install` が実行され、`rake go` が起動します。
+3. ポート `4000` がフォワードされるので、表示される URL からサイトを確認できます。


### PR DESCRIPTION
## Summary
- add `.devcontainer` folder with `devcontainer.json` and Dockerfile
- document how to start the site in GitHub Codespaces

## Testing
- `bundle install --path vendor/bundle` *(fails: 403 Forbidden)*
- `bundle exec rake go` *(fails: gem not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a58fdcdb4832b9e4e21cccd1748a7