### PR TITLE
Add English site support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,6 +11,11 @@ task :build do
   sh "bundle exec jekyll build"
 end
 
+desc "Build the English site"
+task :build_en do
+  sh "bundle exec jekyll build --config _config.yml,en/_config.yml --destination _site/en"
+end
+
 desc "Serve the site locally"
 task :serve do
   sh "bundle exec jekyll serve --watch --livereload"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,6 +5,8 @@ main:
     url: /posts/
   - title: "Pages"
     url: /pages-year/
+  - title: "English"
+    url: /en/
 
 docs:
   - title: "プロジェクトデザインとは"

--- a/en/_config.yml
+++ b/en/_config.yml
@@ -1,0 +1,3 @@
+baseurl: "/pjdhiro/en"
+lang: en
+locale: en-US

--- a/en/_pages/about.md
+++ b/en/_pages/about.md
@@ -1,0 +1,6 @@
+---
+permalink: /en/about/
+title: "About"
+---
+
+This is the about page for the English site.

--- a/en/_pages/index.md
+++ b/en/_pages/index.md
@@ -1,0 +1,9 @@
+---
+layout: myhome
+permalink: /en/
+title: ""
+---
+
+[日本語サイト]({{ '/' | relative_url }})
+
+Welcome to the English version of this site.

--- a/en/_posts/2025-06-01-welcome.md
+++ b/en/_posts/2025-06-01-welcome.md
@@ -1,0 +1,7 @@
+---
+title: "Welcome"
+date: 2025-06-01 00:00:00 +0000
+categories: [General]
+---
+
+This is the first English post.

--- a/index.md
+++ b/index.md
@@ -62,7 +62,9 @@ permalink: /
   </div>
 </div>
 
-[プロジェクトデザイン]({{ '/project-design/' | relative_url }})に関する体験や知見を共有します。  
+[English]({{ '/en/' | relative_url }})
+
+[プロジェクトデザイン]({{ '/project-design/' | relative_url }})に関する体験や知見を共有します。
 特に、[感情処理]({{ '/emotional-processing/' | relative_url }})の視点で整理していきます。
 
 ---


### PR DESCRIPTION
## Summary
- add English config and directories
- create an English home page, about page and sample post
- link to English version from main navigation and index
- add Rake task to build the English site

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle exec rake build_en` *(fails: missing gems)*

------
https://chatgpt.com/codex/tasks/task_e_685a5d4645e0832b9edf2bf9cfc9401c