### PR TITLE
Fix sidebar locale detection

### DIFF
--- a/_includes/nav_list.html
+++ b/_includes/nav_list.html
@@ -3,7 +3,7 @@
   <input id="ac-toc" name="accordion-toc" type="checkbox" />
   <label for="ac-toc">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle Menu" }}</label>
   <ul class="nav__items">
-    {% assign nav_source = site.lang | default: 'ja' %}
+    {% assign nav_source = page.lang | default: site.lang | default: 'ja' %}
     {% if nav_source == 'en' and site.data.en %}
       {% assign nav_data = site.data.en.navigation %}
     {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,7 +3,8 @@
 
 <!doctype html>
 {% include copyright.html %}
-<html lang="{{ site.locale | replace: "_", "-" | default: "en" }}" class="no-js">
+{% assign lang_value = page.lang | default: site.locale %}
+<html lang="{{ lang_value | replace: "_", "-" | default: "en" }}" class="no-js">
   <head>
     {% include head.html %}
     {% include head/custom.html %}


### PR DESCRIPTION
## Summary
- ensure nav_list checks `page.lang`
- set HTML `lang` attribute using page or site locale

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9df47034832ba18f69742e079170