### PR TITLE
Fix English navigation defaults

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -161,7 +161,7 @@ defaults:
   - scope:
       path: "_pages"
       type: pages
-      categories: 
+      categories:
         - 感情処理
     values:
       layout: single
@@ -177,6 +177,10 @@ defaults:
       # pagination: false
       breadcrumbs: true
       exclude_from_yearly: false
+  - scope:
+      path: "en"
+    values:
+      lang: en
 
 # ---------------------------------------------------
 # カテゴリ・タグアーカイブの設定


### PR DESCRIPTION
## Summary
- add `_config.yml` default to set `lang: en` for the `en` directory

## Testing
- `bundle exec jekyll build --config _config.yml,en/_config.yml --quiet` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa80ff984832bbbb6c7be11f28e88